### PR TITLE
Fix undefined displaying in case of year not defined in fonts.json

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,10 +342,16 @@ function updateGutters(cm) {
         $.each(data, function(k,v) {
           font_aliases.push(v.alias);
           $("#select-font").append("<option value=\"" + v.alias + "\">" + v.name + "</option>");
+
+          if (typeof v.year === "undefined") {
+            yearString = "";
+          } else {
+            yearString = " (" + v.year + ")";
+          }
+          
           $("#font-info").append(
             "<p class=\"" + v.alias + "\"> " + v.name +
-            " - " + "<a href=\""+ v.website + "\" rel=\"external\">" + v.author + "</a>" +
-            " (" + v.year + ")" +
+            " - " + "<a href=\""+ v.website + "\" rel=\"external\">" + v.author + "</a>" + yearString +
             "</p>"
           );
         });


### PR DESCRIPTION
If the year of the font is not defined in fonts.json, the interface will display the font name as `BPmono - Backpacker (undefined)`.

This patch checks if the year is defined and, if not, will simply omit the year and brackets.

Before:

![pf_before](https://cloud.githubusercontent.com/assets/9059324/16809163/93467536-4962-11e6-8e47-3cb9d50ce561.png)

After: 
![pf_after](https://cloud.githubusercontent.com/assets/9059324/16809162/93439a46-4962-11e6-8edc-22fb2f0dbc91.png)
