### PR TITLE
Add selected font to url

### DIFF
--- a/index.html
+++ b/index.html
@@ -376,7 +376,14 @@ function updateGutters(cm) {
           custom: { families: font_aliases }
         });
 
-        $("#select-font").val('input'); // default to this awesome font
+        var hash = window.location.hash.substring(1);
+        if(hash){
+          $("#select-font").val(hash);
+        }
+        else {
+          $("#select-font").val('input'); // default to this awesome font
+        }
+
         selectFont();
       });
     });

--- a/index.html
+++ b/index.html
@@ -328,6 +328,7 @@ function updateGutters(cm) {
 
       $("#font-info p").hide();
       $("." + font).show();
+      updateHash();
     }
 
     function setSize() {
@@ -340,7 +341,15 @@ function updateGutters(cm) {
         $(".CodeMirror").addClass("no-smooth");
       }
     }
-
+    function updateHash(){
+      var newHash = '#' + $("#select-font").val();
+      if(history.pushState) {
+        history.pushState(null, null, newHash);
+      }
+      else {
+        location.hash = newHash;
+      }
+    }
     $(document).ready(function(){
 
       //randomly select a theme


### PR DESCRIPTION
Wanted to showcase a font (fira code) to co-workers but couldn't find a way to get a link to send on slack. This patch adds the selected font to the url as a hash.