### PR TITLE
Fix Common Lisp, add Clojure

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,7 @@
 	<script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.50.2/mode/shell/shell.min.js"></script>
 	<script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.50.2/mode/swift/swift.min.js"></script>
 	<script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.50.2/mode/xml/xml.min.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.50.2/mode/clojure/clojure.min.js"></script>
 
 	<link href="//cloud.webtype.com/css/7e544c5e-55dc-4b41-a8d3-c13f7e0a13d3.css" rel="stylesheet" type="text/css" />
 
@@ -242,7 +243,8 @@
 						<option>CSS</option>
 						<option>Go</option>
 						<option>Haskell</option>
-						<option>Lisp</option>
+						<option value="commonlisp">Common Lisp</option>
+						<option>Clojure</option>
 						<option>PHP</option>
 						<option>Perl</option>
 						<option>Python</option>


### PR DESCRIPTION
Thanks for this great project!

The "Lisp" option wasn't working because the codemirror mode is actually called
`commonlisp`.

Also added the Clojure mode.