### PR TITLE
Corrects the information on APL2741 + minor recategorizations

### DIFF
--- a/fonts.json
+++ b/fonts.json
@@ -49,11 +49,11 @@
     },
     "apl2741": {
         "author": "Adrian Smith",
-        "ligatures": false,
+        "ligatures": true,
         "name": "APL2741",
         "rendering": "vector",
-        "style": "serif",
-        "zerostyle": "empty",
+        "style": "sans",
+        "zerostyle": "dotted",
         "variants": [
             "regular"
         ],


### PR DESCRIPTION
Noticed that the **APL2741** fontface was incorrectly categorized, and ended up trying to adjust some other minor stuff I found that _might_ be misclassifications.