### PR TITLE
Update website URL for iA Writer Mono

### DIFF
--- a/fonts.json
+++ b/fonts.json
@@ -758,7 +758,7 @@
         "rendering": "vector",
         "style": "sans",
         "zerostyle": "dotted",
-        "website": "https://ia.net/writer/blog/a-typographic-christmas",
+        "website": "https://ia.net/topics/a-typographic-christmas",
         "year": 2018
     },
     "inconsolata": {


### PR DESCRIPTION
I happened to click the link to the website for iA Writer Mono and wound up on a 404 page. Luckily it was easy to find where it was moved to!

Alternatively, this could also be changed to:
- This Internet Archive capture: https://web.archive.org/web/20220331180020/https://ia.net/writer/blog/a-typographic-christmas
- The GitHub repo: https://github.com/iaolo/iA-Fonts