### PR TITLE
Fix #126: : Line number spacing not updating on zoom

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,12 +81,14 @@ function setSize() {
 
     document.querySelector('.CodeMirror').style.fontSize = `${size}px`;
     document.cookie = `size=${size};max-age=172800`;
+    editor.refresh();
 }
 function setSpacing() {
     var spacing = document.getElementById('spacing').value;
 
     document.querySelector('.CodeMirror').style.lineHeight = spacing;
     document.cookie = `spacing=${spacing};max-age=172800`;
+    editor.refresh();
 }
 function selectLanguage() {
     var lang = document.getElementById('select-language').value;


### PR DESCRIPTION
Fixes https://github.com/braver/programmingfonts/issues/126.

This also fixes the cursor and selected line spacing not updating, which is most obvious when adjusting the line spacing.

Manually firing a refresh event for `selectLanguage` is not necessary as it calls `editor.setOption` which fires this event internally.