### PR TITLE
Expand author names for PT Mono font

### DIFF
--- a/fonts.json
+++ b/fonts.json
@@ -3446,7 +3446,7 @@
     },
     "pt": {
         "added": "bc",
-        "author": "A.Korolkova, I.Chaeva",
+        "author": "Alexandra Korolkova, Isabella Chaeva",
         "description": "PT Mono was developed for the special needs -- for use in forms, tables, work sheets etc.",
         "license": "SIL OFL",
         "ligatures": false,


### PR DESCRIPTION
Authors of other fonts specified using full names like John Smith. Names of authors of PT Mono was shortened to one letter — they should be expanded: A. → Alexandra, I. → Isabella.

Source: https://www.paratype.com/fonts/pt/pt-mono?tab=description